### PR TITLE
Add multiple webhooks functionality

### DIFF
--- a/src/LocalImageModal.ts
+++ b/src/LocalImageModal.ts
@@ -31,9 +31,11 @@ export default class LocalImageModal extends FuzzySuggestModal<TFile> {
 	targetFile: TFile;
 	discordManager: DiscordManager;
 	adapter: FileSystemAdapter;
+	url: string;
 
-	constructor(plugin: DiscordSharePlugin) {
+	constructor(plugin: DiscordSharePlugin, url: string) {
 		super(plugin.app);
+		this.url = url;
 		this.plugin = plugin;
 		this.vault = plugin.app.vault;
 		this.discordManager = plugin.discordManager;
@@ -93,9 +95,13 @@ export default class LocalImageModal extends FuzzySuggestModal<TFile> {
 	async onChooseItem(image: TFile) {
 		const path = this.adapter.getFullPath(image.path);
 		if (path) {
-			await this.discordManager.shareAttachment(path, image.name);
+			await this.discordManager.shareAttachment(
+				path,
+				image.name,
+				this.url
+			);
 		} else {
-			new Notice("Invalid file path.")
+			new Notice("Invalid file path.");
 			console.log(`Invalid file path: ${path}`);
 		}
 	}

--- a/src/WebhookURLModal.ts
+++ b/src/WebhookURLModal.ts
@@ -1,0 +1,41 @@
+import { SuggestModal } from "obsidian";
+import DiscordSharePlugin from "./main";
+
+export interface DiscordWebhook {
+	description: string;
+	url: string;
+}
+
+export class WebhookURLModal extends SuggestModal<DiscordWebhook> {
+	plugin: DiscordSharePlugin;
+
+	resolve: (url: string) => void;
+
+	constructor(plugin: DiscordSharePlugin, resolve: (url: string) => void) {
+		super(plugin.app);
+		this.plugin = plugin;
+		this.resolve = resolve;
+	}
+
+	getSuggestions(
+		query: string
+	): DiscordWebhook[] | Promise<DiscordWebhook[]> {
+		return (
+			this.plugin
+				.getSettingValue("discordWebhookURL")
+				?.filter((webhook) =>
+					webhook.description
+						.toLowerCase()
+						.includes(query.toLowerCase())
+				) || []
+		);
+	}
+
+	renderSuggestion(value: DiscordWebhook, el: HTMLElement) {
+		el.createEl("div", { text: value.description });
+	}
+
+	onChooseSuggestion(item: DiscordWebhook, evt: MouseEvent | KeyboardEvent) {
+		this.resolve(item.url);
+	}
+}

--- a/src/discord/DiscordManager.ts
+++ b/src/discord/DiscordManager.ts
@@ -27,10 +27,14 @@ export default class DiscordManager {
 		this.adapter = plugin.app.vault.adapter as FileSystemAdapter;
 	}
 
-	public async shareAttachment(filePath: string, fileName: string) {
+	public async shareAttachment(
+		filePath: string,
+		fileName: string,
+		url: string
+	) {
 		const RequestEntityTooLargeErrorCode = "Request entity too large";
 		const webhookClient = new WebhookClient({
-			url: this.plugin.getSettingValue("discordWebhookURL") || "",
+			url: url,
 		});
 
 		webhookClient
@@ -61,9 +65,9 @@ export default class DiscordManager {
 			});
 	}
 
-	public async shareEmbed(params: Partial<DiscordEmbedParams>) {
+	public async shareEmbed(params: Partial<DiscordEmbedParams>, url: string) {
 		const webhookClient = new WebhookClient({
-			url: this.plugin.getSettingValue("discordWebhookURL") || "",
+			url: url,
 		});
 
 		if (!params) {
@@ -96,11 +100,11 @@ export default class DiscordManager {
 		let attachmentFile;
 		if (params.image) {
 			attachmentFile = this.metadata.getFirstLinkpathDest(
-				params.image && params.image[0][0] || "", // This is dumb but works for now.
+				(params.image && params.image[0][0]) || "", // This is dumb but works for now.
 				params.file?.path || ""
 			);
 		}
-		
+
 		let attachment = undefined;
 		if (attachmentFile) {
 			embedBuilder.setImage(`attachment://${attachmentFile.name}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import SettingsTab, {
 } from "src/Settings";
 import DiscordHelper from "./discord/DiscordHelper";
 import { DiscordEmbedParams } from "./discord/types";
+import { WebhookURLModal } from "./WebhookURLModal";
 
 export default class DiscordSharePlugin extends Plugin {
 	settings: ISettingsOptions;
@@ -43,7 +44,9 @@ export default class DiscordSharePlugin extends Plugin {
 				if (checking) {
 					return !!discordWebhookURLSet;
 				}
-				new LocalImageModal(this).open();
+				new WebhookURLModal(this, (url: string) => {
+					new LocalImageModal(this, url).open();
+				}).open();
 			},
 		});
 
@@ -68,7 +71,9 @@ export default class DiscordSharePlugin extends Plugin {
 						);
 						return;
 					}
-					this.discordManager.shareEmbed(params);
+					new WebhookURLModal(this, (url: string) => {
+						this.discordManager.shareEmbed(params, url);
+					}).open();
 				} else {
 					new Notice("No active file found.");
 				}
@@ -87,7 +92,9 @@ export default class DiscordSharePlugin extends Plugin {
 				const params: Partial<DiscordEmbedParams> = {
 					description: selection,
 				};
-				this.discordManager.shareEmbed(params);
+				new WebhookURLModal(this, (url: string) => {
+					this.discordManager.shareEmbed(params, url);
+				}).open();
 			},
 		});
 
@@ -107,7 +114,9 @@ export default class DiscordSharePlugin extends Plugin {
 							const params: Partial<DiscordEmbedParams> = {
 								description: selection,
 							};
-							this.discordManager.shareEmbed(params);
+							new WebhookURLModal(this, (url: string) => {
+								this.discordManager.shareEmbed(params, url);
+							}).open();
 						}
 					);
 				});


### PR DESCRIPTION
Allows setting multiple webhooks. Upon using Discord share, the app will now open a selection of them to choose the webhook to use.